### PR TITLE
UI improvements (Material design 2)

### DIFF
--- a/app/src/main/res/drawable/ic_accessibility_check.xml
+++ b/app/src/main/res/drawable/ic_accessibility_check.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#8BC34A"
+        android:fillColor="@color/accessibility_check"
         android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM16.59,7.58L10,14.17l-2.59,-2.58L6,13l4,4 8,-8z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_accessibility_cross.xml
+++ b/app/src/main/res/drawable/ic_accessibility_cross.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#F44336"
+        android:fillColor="@color/accessibility_cross"
         android:pathData="M14.59,8L12,10.59 9.41,8 8,9.41 10.59,12 8,14.59 9.41,16 12,13.41 14.59,16 16,14.59 13.41,12 16,9.41 14.59,8zM12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z"/>
 </vector>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -19,6 +19,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:animateLayoutChanges="true"
+        android:paddingStart="@dimen/margin_small"
         android:paddingEnd="@dimen/margin_small"
         android:id="@+id/toolbar">
 
@@ -31,6 +32,7 @@
             android:layout_gravity="center|bottom"
             android:gravity="center"
             android:paddingStart="@dimen/margin_small"
+            android:paddingEnd="@dimen/margin_small"
             tools:text="Toolbar title"/>
 
     </com.google.android.material.appbar.MaterialToolbar>

--- a/app/src/main/res/layout/fragment_add_action_category.xml
+++ b/app/src/main/res/layout/fragment_add_action_category.xml
@@ -10,7 +10,7 @@
     android:paddingBottom="@dimen/margin_extra_large"
     android:clipToPadding="false">
     
-    <androidx.cardview.widget.CardView
+    <com.google.android.material.card.MaterialCardView
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:id="@+id/add_action_category_launch"
@@ -18,6 +18,10 @@
         android:focusable="true"
         android:clickable="true"
         android:foreground="?selectableItemBackground"
+        app:strokeWidth="1dp"
+        app:strokeColor="@color/card_outlined"
+        app:cardElevation="0dp"
+        app:cardBackgroundColor="@color/windowBackground"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/add_action_category_utilities"
@@ -33,9 +37,9 @@
             android:drawableStart="@drawable/ic_action_category_launch"
             android:textAppearance="@style/TextAppearance.AppCompat.Medium.TapTap.Primary"/>
 
-    </androidx.cardview.widget.CardView>
+    </com.google.android.material.card.MaterialCardView>
 
-    <androidx.cardview.widget.CardView
+    <com.google.android.material.card.MaterialCardView
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:id="@+id/add_action_category_utilities"
@@ -43,6 +47,10 @@
         android:focusable="true"
         android:clickable="true"
         android:foreground="?selectableItemBackground"
+        app:strokeWidth="1dp"
+        app:strokeColor="@color/card_outlined"
+        app:cardElevation="0dp"
+        app:cardBackgroundColor="@color/windowBackground"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/add_action_category_launch"
         app:layout_constraintTop_toTopOf="parent"
@@ -58,9 +66,9 @@
             android:drawableStart="@drawable/ic_action_category_utilities"
             android:textAppearance="@style/TextAppearance.AppCompat.Medium.TapTap.Primary"/>
 
-    </androidx.cardview.widget.CardView>
+    </com.google.android.material.card.MaterialCardView>
 
-    <androidx.cardview.widget.CardView
+    <com.google.android.material.card.MaterialCardView
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:id="@+id/add_action_category_actions"
@@ -69,6 +77,10 @@
         android:focusable="true"
         android:clickable="true"
         android:foreground="?selectableItemBackground"
+        app:strokeWidth="1dp"
+        app:strokeColor="@color/card_outlined"
+        app:cardElevation="0dp"
+        app:cardBackgroundColor="@color/windowBackground"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/add_action_category_launch"
         app:layout_constraintEnd_toStartOf="@+id/add_action_category_advanced"
@@ -84,9 +96,9 @@
             android:drawableStart="@drawable/ic_action_back"
             android:textAppearance="@style/TextAppearance.AppCompat.Medium.TapTap.Primary"/>
 
-    </androidx.cardview.widget.CardView>
+    </com.google.android.material.card.MaterialCardView>
 
-    <androidx.cardview.widget.CardView
+    <com.google.android.material.card.MaterialCardView
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:id="@+id/add_action_category_advanced"
@@ -95,6 +107,10 @@
         android:focusable="true"
         android:clickable="true"
         android:foreground="?selectableItemBackground"
+        app:strokeWidth="1dp"
+        app:strokeColor="@color/card_outlined"
+        app:cardElevation="0dp"
+        app:cardBackgroundColor="@color/windowBackground"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/add_action_category_actions"
         app:layout_constraintTop_toBottomOf="@id/add_action_category_launch"
@@ -110,6 +126,6 @@
             android:drawableStart="@drawable/ic_action_category_advanced"
             android:textAppearance="@style/TextAppearance.AppCompat.Medium.TapTap.Primary"/>
 
-    </androidx.cardview.widget.CardView>
+    </com.google.android.material.card.MaterialCardView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_action.xml
+++ b/app/src/main/res/layout/item_action.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:tools="http://schemas.android.com/tools"
@@ -7,6 +7,10 @@
     android:clickable="true"
     android:focusable="true"
     android:foreground="?selectableItemBackground"
+    app:strokeWidth="1dp"
+    app:strokeColor="@color/card_outlined"
+    app:cardElevation="0dp"
+    app:cardBackgroundColor="@color/windowBackground"
     app:cardCornerRadius="@dimen/margin_small"
     android:layout_marginStart="@dimen/margin_large"
     android:layout_marginEnd="@dimen/margin_extra_small"
@@ -70,4 +74,4 @@
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 
-</androidx.cardview.widget.CardView>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_gate.xml
+++ b/app/src/main/res/layout/item_gate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:tools="http://schemas.android.com/tools"
@@ -7,6 +7,9 @@
     android:clickable="true"
     android:focusable="true"
     android:foreground="?selectableItemBackground"
+    app:strokeWidth="1dp"
+    app:strokeColor="@color/card_outlined"
+    app:cardElevation="0dp"
     app:cardCornerRadius="@dimen/margin_small"
     android:layout_marginStart="@dimen/margin_large"
     android:layout_marginEnd="@dimen/margin_large"
@@ -81,5 +84,4 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-
-</androidx.cardview.widget.CardView>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="colorAccent">#73EBDF</color>
     <color name="windowBackground">#222222</color>
     <color name="toolbarColor">#D9222222</color>
-    <color name="sheet_color">#2D2D2D</color>
+    <color name="sheet_color">#222222</color>
+    <color name="fab_color">@color/colorAccent</color>
+    <color name="fab_color_delete">#F4928B</color>
     <color name="card_selected">#616161</color>
-    <color name="card_background">@color/cardview_dark_background</color>
+    <color name="card_background">@color/windowBackground</color>
+    <color name="card_outlined">#5F6368</color>
+    <color name="accessibility_cross">#F4928B</color>
+    <color name="accessibility_check">#A2C37B</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,9 +5,12 @@
     <color name="colorAccent">#03DAC5</color>
     <color name="windowBackground">#ffffff</color>
     <color name="toolbarColor">#D9ffffff</color>
-    <color name="sheet_color">#F9F9F9</color>
+    <color name="sheet_color">#ffffff</color>
     <color name="fab_color">@color/colorAccent</color>
     <color name="fab_color_delete">#F44336</color>
     <color name="card_background">@color/cardview_light_background</color>
     <color name="card_selected">#BDBDBD</color>
+    <color name="card_outlined">#DADCE0</color>
+    <color name="accessibility_cross">#F44336</color>
+    <color name="accessibility_check">#8BC34A</color>
 </resources>


### PR DESCRIPTION
**Type of improvement:** related to the user interface

**What has been changed?**

1. Fixed some drawables with hardcoded colors.
2. Added desaturated colors for the dark mode, exactly as described in the material design guidelines.
3. The material cards are now outlined.
4. Fixed action cards in the action section that do not correctly comply with the dark mode.

**Screenshots - Light theme**
![0](https://user-images.githubusercontent.com/30368951/89048689-7448e480-d350-11ea-8124-2f65e5ed6bdd.jpg)
![1](https://user-images.githubusercontent.com/30368951/89048700-790d9880-d350-11ea-8a30-14a156a4752b.jpg)
![2](https://user-images.githubusercontent.com/30368951/89048730-87f44b00-d350-11ea-8dd8-c25e66b23fa7.jpg)
![3](https://user-images.githubusercontent.com/30368951/89048732-89be0e80-d350-11ea-9d59-f589464c6bbf.jpg)
![4](https://user-images.githubusercontent.com/30368951/89048739-8b87d200-d350-11ea-96b1-6f5da22d62c8.jpg)
![5](https://user-images.githubusercontent.com/30368951/89048755-8e82c280-d350-11ea-900a-9e3e33ec4ce8.jpg)

**Screenshots - Dark theme**

![6](https://user-images.githubusercontent.com/30368951/89048814-a5291980-d350-11ea-9a13-1dd68680a8d9.jpg)
![7](https://user-images.githubusercontent.com/30368951/89048821-a6f2dd00-d350-11ea-8ee1-ed8f2efdaaf3.jpg)
![8](https://user-images.githubusercontent.com/30368951/89048839-abb79100-d350-11ea-9f64-ad9e58e6263f.jpg)
![9](https://user-images.githubusercontent.com/30368951/89048919-c1c55180-d350-11ea-80c9-2b963f31b4ed.jpg)
![10](https://user-images.githubusercontent.com/30368951/89048927-c38f1500-d350-11ea-922b-2bf3e0f9da6d.jpg)
![11](https://user-images.githubusercontent.com/30368951/89048937-c7229c00-d350-11ea-9b91-b05f72afe247.jpg)
![12](https://user-images.githubusercontent.com/30368951/89048944-c7bb3280-d350-11ea-9d83-788e8e88d91e.jpg)
![13](https://user-images.githubusercontent.com/30368951/89048949-c8ec5f80-d350-11ea-80d6-271ae7a96504.jpg)
![14](https://user-images.githubusercontent.com/30368951/89048957-ca1d8c80-d350-11ea-915d-b427f61f537a.jpg)



