### PR TITLE
1.2

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -46,6 +46,9 @@
         <entry key="..\:/Users/Kieron/Android/AndroidStudioWorkspace/TapTapv2/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml" value="0.29375" />
         <entry key="app/src/main/res/drawable/ic_gate_battery_saver.xml" value="0.2989583333333333" />
         <entry key="app/src/main/res/drawable/ic_gate_low_battery.xml" value="0.2989583333333333" />
+        <entry key="app/src/main/res/drawable/ic_launcher_foreground.xml" value="0.299" />
+        <entry key="app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml" value="0.299" />
+        <entry key="app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml" value="0.299" />
       </map>
     </option>
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ plugins {
 //Permission for Columbus to use
 rootProject.ext.set("columbusPermission", "com.google.android.columbus.taptap.permission.CONFIGURE_COLUMBUS_GESTURE")
 
-def tagName = '1.1'
+def tagName = '1.2'
 
 android {
     compileSdk 32
@@ -21,8 +21,8 @@ android {
         applicationId "com.kieronquinn.app.taptap"
         minSdk 24
         targetSdk 32
-        versionCode 1100
-        versionName "1.1"
+        versionCode 1200
+        versionName tagName
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
@@ -72,10 +72,10 @@ dependencies {
     implementation "androidx.core:core-ktx:1.7.0"
     implementation "androidx.vectordrawable:vectordrawable-seekable:1.0.0-alpha02"
     implementation "androidx.core:core-splashscreen:1.0.0-beta01"
-    implementation "androidx.fragment:fragment-ktx:1.4.0"
+    implementation "androidx.fragment:fragment-ktx:1.4.1"
 
     //Lifecycle
-    def lifecycleVersion = '2.4.0'
+    def lifecycleVersion = '2.4.1'
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-service:$lifecycleVersion"
@@ -113,10 +113,6 @@ dependencies {
 
     //Gson for serialization
     implementation 'com.google.code.gson:gson:2.8.9'
-
-    //Leave as-is for foldable checks without activity
-    //noinspection GradleDependency
-    implementation "androidx.window:window:1.0.0-alpha02"
 
     //Columbus module is separate to make it easier to work with
     implementation project(path: ':columbus')

--- a/app/release/output-metadata.json
+++ b/app/release/output-metadata.json
@@ -11,8 +11,8 @@
       "type": "SINGLE",
       "filters": [],
       "attributes": [],
-      "versionCode": 1010,
-      "versionName": "1.0.1",
+      "versionCode": 1100,
+      "versionName": "1.1",
       "outputFile": "app-release.apk"
     }
   ],

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
     <uses-permission android:name="net.dinglisch.android.tasker.PERMISSION_RUN_TASKS" />
+    <uses-permission android:name="com.android.alarm.permission.SET_ALARM"/>
     <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"
         tools:ignore="HighSamplingRate" />
 

--- a/app/src/main/java/com/kieronquinn/app/taptap/components/columbus/gates/custom/FoldableClosedGate.kt
+++ b/app/src/main/java/com/kieronquinn/app/taptap/components/columbus/gates/custom/FoldableClosedGate.kt
@@ -2,9 +2,9 @@ package com.kieronquinn.app.taptap.components.columbus.gates.custom
 
 import android.content.Context
 import androidx.lifecycle.Lifecycle
-import androidx.window.FoldingFeature
 import com.kieronquinn.app.taptap.components.columbus.gates.PassiveGate
 import com.kieronquinn.app.taptap.components.columbus.gates.TapTapGate
+import com.kieronquinn.app.taptap.utils.extensions.FoldingFeature_STATE_HALF_OPENED
 import com.kieronquinn.app.taptap.utils.foldable.SidecarProvider
 
 class FoldableClosedGate(
@@ -22,7 +22,7 @@ class FoldableClosedGate(
     }
 
     override fun isBlocked(): Boolean {
-        return sidecarProvider?.getDevicePosture() == FoldingFeature.STATE_FLAT
+        return sidecarProvider?.getDevicePosture() == FoldingFeature_STATE_HALF_OPENED
     }
 
 }

--- a/app/src/main/java/com/kieronquinn/app/taptap/components/columbus/gates/custom/FoldableOpenGate.kt
+++ b/app/src/main/java/com/kieronquinn/app/taptap/components/columbus/gates/custom/FoldableOpenGate.kt
@@ -2,9 +2,9 @@ package com.kieronquinn.app.taptap.components.columbus.gates.custom
 
 import android.content.Context
 import androidx.lifecycle.Lifecycle
-import androidx.window.FoldingFeature
 import com.kieronquinn.app.taptap.components.columbus.gates.PassiveGate
 import com.kieronquinn.app.taptap.components.columbus.gates.TapTapGate
+import com.kieronquinn.app.taptap.utils.extensions.FoldingFeature_STATE_FLAT
 import com.kieronquinn.app.taptap.utils.foldable.SidecarProvider
 
 class FoldableOpenGate(
@@ -22,7 +22,7 @@ class FoldableOpenGate(
     }
 
     override fun isBlocked(): Boolean {
-        return sidecarProvider?.getDevicePosture() == FoldingFeature.STATE_FLIPPED
+        return sidecarProvider?.getDevicePosture() == FoldingFeature_STATE_FLAT
     }
 
 }

--- a/app/src/main/java/com/kieronquinn/app/taptap/components/settings/TapTapSettings.kt
+++ b/app/src/main/java/com/kieronquinn/app/taptap/components/settings/TapTapSettings.kt
@@ -81,7 +81,7 @@ interface TapTapSettings {
     //Automatically restart the service periodically
     val advancedAutoRestart: TapTapSetting<Boolean>
 
-    //Whether to use EXECUTION_PREFERENCE_LOW_POWER for the nnapidelegate (tensor only) - default on
+    //Whether to use EXECUTION_PREFERENCE_LOW_POWER for the nnapidelegate (tensor only) - default OFF
     val advancedTensorLowPower: TapTapSetting<Boolean>
 
     //Whether the user has previously given sui permission - this is NOT used for the service, and is always verified
@@ -222,7 +222,7 @@ class TapTapSettingsImpl(context: Context) : TapTapSettings {
         const val KEY_ADVANCED_CUSTOM_SENSITIVITY = "advanced_custom_sensitivity"
 
         const val KEY_ADVANCED_TENSOR_LOW_POWER = "advanced_tensor_low_power"
-        const val DEFAULT_ADVANCED_TENSOR_LOW_POWER = true
+        const val DEFAULT_ADVANCED_TENSOR_LOW_POWER = false
 
         const val KEY_HAS_PREVIOUSLY_GRANTED_SUI = "has_previously_granted_sui"
         const val DEFAULT_HAS_PREVIOUSLY_GRANTED_SUI = false

--- a/app/src/main/java/com/kieronquinn/app/taptap/ui/screens/settings/shared/selector/appshortcuts/SettingsSharedAppShortcutsSelectorViewModel.kt
+++ b/app/src/main/java/com/kieronquinn/app/taptap/ui/screens/settings/shared/selector/appshortcuts/SettingsSharedAppShortcutsSelectorViewModel.kt
@@ -162,7 +162,7 @@ class SettingsSharedAppShortcutsSelectorViewModelImpl(context: Context, private 
         return file
     }
 
-    private fun copyIconToCache(icon: Icon?, context: Context, shortcutId: String): File? {
+    private fun copyIconToCache(icon: Icon?, context: Context, shortcutId: String): File? = runCatching {
         if(icon == null) return null
         val file = File(cacheDir, "$shortcutId.png")
         val drawable = icon.loadDrawable(context)
@@ -175,6 +175,6 @@ class SettingsSharedAppShortcutsSelectorViewModelImpl(context: Context, private 
             bitmap.recycle()
         }
         return file
-    }
+    }.getOrDefault(null)
 
 }

--- a/app/src/main/java/com/kieronquinn/app/taptap/utils/extensions/Extensions+FoldingFeature.kt
+++ b/app/src/main/java/com/kieronquinn/app/taptap/utils/extensions/Extensions+FoldingFeature.kt
@@ -1,0 +1,4 @@
+package com.kieronquinn.app.taptap.utils.extensions
+
+const val FoldingFeature_STATE_FLAT = 1
+const val FoldingFeature_STATE_HALF_OPENED = 1

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -219,7 +219,7 @@
     <string name="setting_advanced_legacy_wake">Устаревший метод пробуждения устройства</string>
     <string name="setting_advanced_legacy_wake_desc">Использовать классический метод для работы опции «Включение устройства». Работает не на всех устройствах, но в редких случаях может оказаться более надежным решением.</string>
     <string name="setting_advanced_tensor_low_power">Снижение нагрузки на осн. ядра</string>
-    <string name="setting_advanced_tensor_low_power_desc">Запускает модель распознавания жестов на энергоэффективных ядрах процессора, если доступно; в случае проблем с производительностью отключите опцию.\n<b>По умолчанию включено</b></string>
+    <string name="setting_advanced_tensor_low_power_desc">Запускает модель распознавания жестов на энергоэффективных ядрах процессора, если доступно; в случае проблем с производительностью отключите опцию.</string>
     <string name="settings_advanced_monet_color_picker">Цвет темы из обоев</string>
     <string name="settings_advanced_monet_color_picker_desc">Для интерфейса Tap, Tap использовать палитру на основе цвета ваших обоев</string>
     <string name="setting_advanced_custom_sensitivity">Свое значение чувствительности</string>
@@ -327,7 +327,7 @@
     <string name="action_notifications">Панель уведомлений</string>
     <string name="action_notifications_desc">Открыть шторку с уведомлениями. На поддерживаемых устройствах это действие также может сворачивать шторку обратно</string>
     <string name="action_quick_settings">Быстрые настройки</string>
-    <string name="action_quick_settings_desc">Открывает панель быстрого доступа. На поддерживаемых устройствах это действие также может сворачивать шторку обратно/string>
+    <string name="action_quick_settings_desc">Открывает панель быстрого доступа. На поддерживаемых устройствах это действие также может сворачивать шторку обратно</string>
     <string name="action_screenshot">Снимок экрана</string>
     <string name="action_screenshot_desc">Сделать скриншот системными средствами</string>
     <string name="action_lock_screen">Выключение экрана</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -219,7 +219,7 @@
     <string name="setting_advanced_legacy_wake">Legacy Wake Device method</string>
     <string name="setting_advanced_legacy_wake_desc">Use the legacy method of waking the device with the \'Wake Device\' option enabled. This may not work on all devices, but may be more reliable in a few rare cases.</string>
     <string name="setting_advanced_tensor_low_power">Tensor Low Power Mode</string>
-    <string name="setting_advanced_tensor_low_power_desc">Runs the Tensor model on the low power CPU if available; disable if you have performance issues.\n<b>Default enabled</b></string>
+    <string name="setting_advanced_tensor_low_power_desc">Runs the Tensor model on the low power CPU if available; disable if you have performance issues or the gesture stops working entirely.</string>
     <string name="settings_advanced_monet_color_picker">Wallpaper Colour</string>
     <string name="settings_advanced_monet_color_picker_desc">Choose the colour from your wallpaper to use throughout Tap, Tap\'s UI</string>
     <string name="setting_advanced_custom_sensitivity">Custom sensitivity</string>

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext {
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.protobufVersion = '0.8.17'
-    ext.nav_version = '2.3.5'
+    ext.nav_version = '2.4.1'
     ext.refine_version = '3.0.3'
     repositories {
         google()
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.4'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
         classpath "com.google.protobuf:protobuf-gradle-plugin:$protobufVersion"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
         classpath "dev.rikka.tools.refine:gradle-plugin:$refine_version"


### PR DESCRIPTION
- Disabled Tensor Low Power Mode by default as it was causing issues with some devices not working with the gesture
- Added missing ALARM permission
- Fixed shortcut bitmap crash if the sent image is empty
- Moved away from androidx.window for foldable feature as we use the core system androidx instead
- Added monochrome icon for Android 13