### PR TITLE
feat: add touch on screen action

### DIFF
--- a/app/src/main/java/com/kieronquinn/app/taptap/components/accessibility/TapTapAccessibilityRouter.kt
+++ b/app/src/main/java/com/kieronquinn/app/taptap/components/accessibility/TapTapAccessibilityRouter.kt
@@ -19,6 +19,7 @@ interface TapTapAccessibilityRouter {
             }
         }
         object PerformHamburgerClick: GestureInput()
+        object PerformSingleTouch: GestureInput()
     }
 
     sealed class AccessibilityOutput {

--- a/app/src/main/java/com/kieronquinn/app/taptap/components/columbus/actions/custom/TouchAction.kt
+++ b/app/src/main/java/com/kieronquinn/app/taptap/components/columbus/actions/custom/TouchAction.kt
@@ -1,0 +1,33 @@
+package com.kieronquinn.app.taptap.components.columbus.actions.custom
+
+import android.content.Context
+import androidx.lifecycle.Lifecycle
+import com.google.android.columbus.feedback.FeedbackEffect
+import com.google.android.columbus.sensors.GestureSensor
+import com.kieronquinn.app.taptap.components.accessibility.TapTapAccessibilityRouter
+import com.kieronquinn.app.taptap.components.columbus.actions.TapTapAction
+import com.kieronquinn.app.taptap.components.columbus.gates.TapTapWhenGate
+import org.koin.core.component.inject
+
+class TouchAction(
+    serviceLifecycle: Lifecycle,
+    private val context: Context,
+    whenGates: List<TapTapWhenGate>,
+    effects: Set<FeedbackEffect>
+) : TapTapAction(
+    serviceLifecycle, context, whenGates, effects
+) {
+
+    private val accessibilityRouter by inject<TapTapAccessibilityRouter>()
+
+    override val tag = "TouchAction"
+
+    override suspend fun onTriggered(
+        detectionProperties: GestureSensor.DetectionProperties,
+        isTripleTap: Boolean
+    ) {
+        if(showGestureAccessibilityNotificationIfNeeded()) return
+        accessibilityRouter.postInput(TapTapAccessibilityRouter.AccessibilityInput.PerformSingleTouch)
+    }
+
+}

--- a/app/src/main/java/com/kieronquinn/app/taptap/models/action/TapTapActionDirectory.kt
+++ b/app/src/main/java/com/kieronquinn/app/taptap/models/action/TapTapActionDirectory.kt
@@ -473,6 +473,15 @@ enum class TapTapActionDirectory(
         dataType = ActionDataTypes.QUICK_SETTING,
         actionSupportedRequirement = null,
         actionRequirement = arrayOf(ActionRequirement.Shizuku)
+    ),
+    TOUCH(
+        TouchAction::class.java,
+        TapTapActionCategory.GESTURE,
+        R.string.action_touch,
+        R.string.action_touch_desc,
+        R.drawable.ic_action_touch,
+        ActionSupportedRequirement.MinSdk(Build.VERSION_CODES.N),
+        actionRequirement = arrayOf(ActionRequirement.GestureAccessibility)
     );
 
     companion object {

--- a/app/src/main/java/com/kieronquinn/app/taptap/repositories/actions/ActionsRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/taptap/repositories/actions/ActionsRepository.kt
@@ -653,6 +653,12 @@ class ActionsRepositoryImpl(
                 serviceRepository,
                 action.extraData
             )
+            TOUCH -> TouchAction(
+                serviceLifecycle,
+                context,
+                whenGates,
+                emptySet()
+            )
         }
     }
 

--- a/app/src/main/java/com/kieronquinn/app/taptap/service/accessibility/TapTapGestureAccessibilityService.kt
+++ b/app/src/main/java/com/kieronquinn/app/taptap/service/accessibility/TapTapGestureAccessibilityService.kt
@@ -104,6 +104,9 @@ class TapTapGestureAccessibilityService : LifecycleAccessibilityService() {
             is TapTapAccessibilityRouter.AccessibilityInput.PerformHamburgerClick -> {
                 performHamburgerClick()
             }
+            is TapTapAccessibilityRouter.AccessibilityInput.PerformSingleTouch -> {
+                performSingleTouch()
+            }
         }
     }
 
@@ -124,6 +127,13 @@ class TapTapGestureAccessibilityService : LifecycleAccessibilityService() {
             val gesture = createClick(25f.px, getStaticStatusBarHeight(
                 this@TapTapGestureAccessibilityService
             ) + 25f.px)
+            dispatchGesture(gesture, null, null)
+        }
+    }
+
+    private fun performSingleTouch() {
+        rootInActiveWindow?.run {
+            val gesture = createClick(100f.px, 100f.px)
             dispatchGesture(gesture, null, null)
         }
     }

--- a/app/src/main/res/drawable/ic_action_touch.xml
+++ b/app/src/main/res/drawable/ic_action_touch.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="?android:textColorPrimary"
+      android:pathData="M10,9A1,1 0,0 1,11 8A1,1 0,0 1,12 9V13.47L13.21,13.6L18.15,15.79C18.68,16.03 19,16.56 19,17.14V21.5C18.97,22.32 18.32,22.97 17.5,23H11C10.62,23 10.26,22.85 10,22.57L5.1,18.37L5.84,17.6C6.03,17.39 6.3,17.28 6.58,17.28H6.8L10,19V9M7,6L4,3L1,6H3V12H5V6H7Z"/>
+</vector>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -91,4 +91,6 @@
     <string name="action_launch_shortcut_desc_formattable">Abrir %1s (atalho do app)</string>
     <string name="action_launch_shortcut_toast">Atualmente, este atalho não é suportado</string>
     <string name="call_phone_permission_toast">Você precisa conceder ao Tap, Tap a permissão \"Telefone\" para usar este atalho como Ação. Faça isso nas configurações de permissões do seu dispositivo.</string>
+    <string name="action_touch">Toque na tela</string>
+    <string name="action_touch_desc">Pressiona a tela em um local aleatório para gerar um gesto de toque.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -644,6 +644,8 @@
     <string name="crash_reporting_content_intro"><![CDATA[Tap, Tap has encountered a crash. Please report the issue, including the report, on the <a href="https://kieronquinn.co.uk/redirect/TapTap/github">GitHub issues</a> or <a href="https://kieronquinn.co.uk/redirect/TapTap/xda">XDA thread</a>. If the crash happened when running the gesture, an action or using a gate, please include screenshots of the setup you are using.<br><br><b>Important: Before reporting, please make sure the issue has not been reported already, using the provided search tools.</b><br><br>The report is also shown below.]]></string>
     <string name="crash_reporting_toast_success">Report saved</string>
     <string name="crash_reporting_toast_failed">Error saving report</string>
+    <string name="action_touch">Touch on screen</string>
+    <string name="action_touch_desc">This action presses the screen at a random point to generate a touch gesture.</string>
 
 
 </resources>


### PR DESCRIPTION
This MR adds a simple touch gesture action as suggested on #203. It can be very useful for Google Cardboard users for example where the screen is usually hidden and most users don't have spare magnets. 
A single touch anywhere on the screen is translated into a click where the user is looking at in VR.

What is missing:
- Custom icon (rn the icon is the same as it is for the swipe up action)
- Translations (added `en` and `pt-br`)
- Testing (couldn't test it on my Mi 11, looks like accessibility services are broken in MiUI)